### PR TITLE
Viewpager deprecated pkg upgrade

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,11 +4,6 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@react-native-community/viewpager": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@react-native-community/viewpager/-/viewpager-3.3.0.tgz",
-      "integrity": "sha512-tyzh79l4t/hxiyS9QD3LRmWMs8KVkZzjrkQ8U8+8To1wmvVCBtp8BenvNsDLTBO7CpO/YmiThpmIdEZMr1WuVw=="
-    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -41,6 +36,11 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "react-native-pager-view": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/react-native-pager-view/-/react-native-pager-view-6.1.4.tgz",
+      "integrity": "sha512-fmTwgGwPxGCBusKAq7gHzm+s1Yp0qh5rKPoQszaCuxrb+76KgK4Qe82jJNPUp2xTZOKSw+FbJU2QahF8ncTl+w=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "homepage": "https://github.com/habilelabs/React-Native-ViewPager#readme",
   "dependencies": {
-    "react-native-pager-view": "^6.1.3",
+    "react-native-pager-view": "^6.1.4",
     "prop-types": "^15.7.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "homepage": "https://github.com/habilelabs/React-Native-ViewPager#readme",
   "dependencies": {
-    "@react-native-community/viewpager": "^3.3.0",
+    "react-native-pager-view": "^6.1.3",
     "prop-types": "^15.7.2"
   }
 }

--- a/viewpager/ViewPager.js
+++ b/viewpager/ViewPager.js
@@ -5,7 +5,7 @@
 'use strict'
 
 import { PanResponder, Platform, ScrollView, StyleSheet, View } from 'react-native'
-import ViewPagerAndroid from "@react-native-community/viewpager";
+import ViewPagerAndroid from "react-native-pager-view";
 import React, { Component } from 'react'
 
 const SCROLL_STATE = {


### PR DESCRIPTION
[npmjs site for /@react-native-community/viewpager](https://www.npmjs.com/package/@react-native-community/viewpager) says:

This package has been deprecated
Author message:

This library is no longer supported. Please use react-native-pager-view instead

This is also useful for people who are using recent versions of react-navigation (v5, v6) and need a single (and updated) View Pager component without conflicts